### PR TITLE
Fix: #151 saving edited events via modal

### DIFF
--- a/src/settings/modals/event/event.ts
+++ b/src/settings/modals/event/event.ts
@@ -37,11 +37,12 @@ export class CreateEventModal extends CalendariumModal {
         type: EventType.Date,
     };
     $UI: EventCreator;
+
     constructor(
         public calendar: Calendar,
         public plugin: Calendarium,
         event?: CalEvent,
-        date?: CalDate | CalEventDate | UndatedCalDate
+        date?: CalDate | CalEventDate | UndatedCalDate,
     ) {
         super(plugin.app);
         if (event) {
@@ -76,9 +77,11 @@ export class CreateEventModal extends CalendariumModal {
     async onOpen() {
         await this.display();
     }
+
     onClose(): void {
         this.$UI?.$destroy();
     }
+
     async checkCanExit() {
         if (this.isValidEvent()) return true;
         if (SettingsService.getData().exit.savingEvent) return true;
@@ -90,7 +93,7 @@ export class CreateEventModal extends CalendariumModal {
                     cta: "Exit",
                     secondary: "Cancel",
                     dontAsk: "Exit and don't ask again",
-                }
+                },
             );
             modal.onClose = async () => {
                 if (modal.dontAsk) {
@@ -102,6 +105,7 @@ export class CreateEventModal extends CalendariumModal {
             modal.open();
         });
     }
+
     isValidEvent() {
         if (!this.event.name) return false;
         if (
@@ -136,7 +140,7 @@ export async function addEventWithModal(
     plugin: Calendarium,
     calendar: Calendar,
     date: CalDate | CalEventDate | UndatedCalDate,
-    event?: CalEvent
+    event?: CalEvent,
 ) {
     const modal = new CreateEventModal(calendar, plugin, event, date);
 
@@ -144,7 +148,12 @@ export async function addEventWithModal(
         if (!modal.saved) return;
         const store = plugin.getStoreByCalendar(calendar);
         if (!store) return;
-        calendar.events.push(modal.event);
+        if (event) {
+            const index = calendar.events.findIndex(event => event.id === modal.event.id);
+            calendar.events.splice(index, 1, modal.event);
+        } else {
+            calendar.events.push(modal.event);
+        }
         store.eventStore.insertEvents(modal.event);
 
         await SettingsService.saveCalendars();


### PR DESCRIPTION
The edit modal was pushing the "edited" event into the calendar events instead of replacing it.

## Pull Request Description

When the `addEventWithModal` is called with an event as parameter it now assumes that it is editing. As such it will replace the old event with the new event based on its `id` instead of just pushing it to the data to be saved.

## Related Issues

Fixes #151

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [ ] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

BEGIN_COMMIT_OVERRIDE
fix: Saving edited events via modal no longer duplicates events (close #151). Thanks [@LexMonster](https://github.com/LexMonster).
END_COMMIT_OVERRIDE