### PR TITLE
138 end of month cutoff

### DIFF
--- a/src/stores/cache/event-cache.ts
+++ b/src/stores/cache/event-cache.ts
@@ -85,6 +85,11 @@ class MonthEventCache extends MonthCache<CalEvent> {
                     const date = { ...event.date };
                     const end = { ...event.end };
 
+                    console.log('date');
+                    console.log(date);
+                    console.log('end');
+                    console.log(end);
+
                     //Year and Month match
                     if (date.year == this.year && date.month == this.month)
                         return true;
@@ -109,6 +114,15 @@ class MonthEventCache extends MonthCache<CalEvent> {
                     if (
                         date.year < this.year &&
                         end.year == this.year &&
+                        end.month >= this.month
+                    ) {
+                        return true;
+                    }
+
+                    // Event lies within a range of multiple months in a single year
+                    if(
+                        date.year == this.year && 
+                        date.month <= this.month && 
                         end.month >= this.month
                     ) {
                         return true;


### PR DESCRIPTION
## Pull Request Description

Provides a fix for #138.

## Changes Proposed

- Fixes #138 by adding a case where the event year is equal to the date year and the event month lies between the date month and the end month (inclusive).

## Related Issues

Fixes #138

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [ ] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/562c4154-7d69-44d9-aec6-660b372ee24e)

## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->
