### PR TITLE
scope date style to leaf content

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,20 +31,22 @@ settings:
 body {
   --calendarium-span-data-color: var(--text-accent);
 }
-body:not(.calendarium-nix-spans) span[data-date]:not(.hide-data),
-body:not(.calendarium-nix-spans) div[data-date]:not(.hide-data) {
-  font-style: var(--calendarium-span-data-style, italic);
-  font-weight: var(--calendarium-span-data-weight, 500);
-}
-body:not(.calendarium-nix-spans) span[data-date]:not([data-end]):not(.hide-data)::before,
-body:not(.calendarium-nix-spans) div[data-date]:not([data-end]):not(.hide-data)::before {
-  content: "🔖 " attr(data-date) ": " attr(data-name) ". ";
-  color: var(--calendarium-span-data-color, var(--text-accent));
-  font-weight: 500;
-}
-body:not(.calendarium-nix-spans) span[data-date][data-end]:not(.hide-data)::before,
-body:not(.calendarium-nix-spans) div[data-date][data-end]:not(.hide-data)::before {
-  content: "🔖 " attr(data-date) " to " attr(data-end) ": " attr(data-name) ". ";
-  color: var(--calendarium-span-data-color, var(--text-accent));
-  font-weight: 500;
+body:not(.calendarium-nix-spans) .workspace-leaf-content[data-type=markdown] {
+  span[data-date]:not(.hide-data),
+  div[data-date]:not(.hide-data) {
+    font-style: var(--calendarium-span-data-style, italic);
+    font-weight: var(--calendarium-span-data-weight, 500);
+  }
+  span[data-date]:not([data-end]):not(.hide-data)::before,
+  div[data-date]:not([data-end]):not(.hide-data)::before {
+    content: "🔖 " attr(data-date) ": " attr(data-name) ". ";
+    color: var(--calendarium-span-data-color, var(--text-accent));
+    font-weight: 500;
+  }
+  span[data-date][data-end]:not(.hide-data)::before,
+  div[data-date][data-end]:not(.hide-data)::before {
+    content: "🔖 " attr(data-date) " to " attr(data-end) ": " attr(data-name) ". ";
+    color: var(--calendarium-span-data-color, var(--text-accent));
+    font-weight: 500;
+  }
 }


### PR DESCRIPTION
Resolve some style conflicts by scoping span styles to markdown leaf content (whether in the sidebar or not).

This won't fix all potential conflicts. As always, the plugin-provided style can be disabled and copied into a better-tuned snippet.

BEGIN_COMMIT_OVERRIDE
fix: scope date style to leaf content
END_COMMIT_OVERRIDE