### PR TITLE
Command for quickly inserting current date from default calendar

### DIFF
--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -116,7 +116,7 @@ export class CalendarAPI {
      * @param {string} dateFormat Optional date format string
      * @returns formatted string
      */
-    toDisplayDate(date: CalDate, end?: CalDate, dateFormat?: string): string {
+    toDisplayDate(date: CalDate, end?: CalDate | null, dateFormat?: string): string {
         return dateString(date, this.#object, end, dateFormat);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,6 +230,9 @@ export default class Calendarium extends Plugin {
         const currentCalDate = calendar.current;
         const calendarApi = api.getAPI(calendar.name);
         const dateString = calendarApi.toDisplayDate(currentCalDate, calendar.dateFormat);
-        editor.replaceRange(dateString, editor.getCursor());
+        const cursor = editor.getCursor();
+        editor.replaceRange(dateString, cursor);
+        cursor.ch += dateString.length;
+        editor.setCursor(cursor);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,6 +197,7 @@ export default class Calendarium extends Plugin {
         this.addCommand({
             id: "insert-calendarium-current-date",
             name: "Insert Current Date",
+            /* Insert the current date from the default calendar at the current cursor location. */
             editorCallback: (editor: Editor, view: MarkdownView) => {
                 this.insertCurrentDate(this.settings$.getDefaultCalendar(), editor, this.api);
             },

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,6 +193,14 @@ export default class Calendarium extends Plugin {
                 this.addCalendarView();
             },
         });
+
+        this.addCommand({
+            id: "insert-calendarium-current-date",
+            name: "Insert Current Date",
+            editorCallback: (editor: Editor, view: MarkdownView) => {
+                this.insertCurrentDate(this.settings$.getDefaultCalendar(), editor, this.api);
+            },
+        });
     }
 
     addCalendarView(params: { full?: boolean; startup?: boolean } = {}) {
@@ -215,5 +223,12 @@ export default class Calendarium extends Plugin {
         if (leaf) this.app.workspace.revealLeaf(leaf);
 
         return leaf;
+    }
+
+    insertCurrentDate(calendar: Calendar, editor: Editor, api: API) {
+        const currentCalDate = calendar.current;
+        const calendarApi = api.getAPI(calendar.name);
+        const dateString = calendarApi.toDisplayDate(currentCalDate, calendar.dateFormat);
+        editor.replaceRange(dateString, editor.getCursor());
     }
 }


### PR DESCRIPTION
## Pull Request Description

Adds a new command as describe. This will enable it to be bound to hotkeys, etc. as users desire.

## Changes Proposed

Registers new command in main.ts, along with implementation.

## Related Issues

This is related to https://github.com/javalent/calendarium/issues/133, my original intention was to address that but just being able to quickly view the current date was a pre-requisite.


## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues - N/A
- [x] I have checked for any potential security issues or vulnerabilities.

BEGIN_COMMIT_OVERRIDE
feat: Adds command for quickly inserting current date from default calendar
END_COMMIT_OVERRIDE