### PR TITLE
Fix display era toggle in settings

### DIFF
--- a/src/calendar/ui/Nav.svelte
+++ b/src/calendar/ui/Nav.svelte
@@ -99,6 +99,7 @@
             item.setTitle(`Show era`)
                 .onClick(async () => {
                     $hideEra = !$hideEra;
+                    $global.eventStore.calendar.hideEra = $hideEra;
                 })
                 .setChecked(!$hideEra);
         });

--- a/src/settings/creator/Containers/eras/EraContainer.svelte
+++ b/src/settings/creator/Containers/eras/EraContainer.svelte
@@ -30,7 +30,11 @@
     };
 
     const toggleEra = (node: HTMLElement) => {
-        new ToggleComponent(node).setValue($calendar.hideEra ?? true);
+        new ToggleComponent(node)
+            .setValue(!$calendar.hideEra)
+            .onChange(bool => { 
+                $calendar.hideEra = !bool;
+             });
     };
 </script>
 


### PR DESCRIPTION
## Pull Request Description

Fix the Display eras on calender toggle found in settings to adress issue #199 

## Changes Proposed

Nav.svelte needed to change to ensure that the toggle in `Calendar Creator>Eras>Display eras on calendar` stays synchronized with the toggle in the dropdown in the calendar settings.
The changes in EraContainer.svelte should be fairly self-explanatory.

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #199

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [-] My code follows the coding style and standards of this project. | See notes
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes

There's probably a more elegant way to link the two `$hideEra` variables together than `$global.eventStore.calendar.hideEra = $hideEra;`, given that this is a pattern that I've not seen anywhere else in the codebase yet.
Unfortunately, I couldn't find one. This is the first time I'm working with Svelte, so if I've missed something obvious I'd be glad to hear it.

Running `npm audit fix` also fixes numerous vulnerabilities in the project's dependencies, including some `critical` level ones.
I considered it to be out of the scope of this pull request as they were unrelated to my code, however it might be something to do separately.
