### PR TITLE
Fix bug related to issue #187

### DIFF
--- a/src/settings/creator/Containers/events/CategoryContainer.svelte
+++ b/src/settings/creator/Containers/events/CategoryContainer.svelte
@@ -51,7 +51,7 @@
         />
     {:else}
         <div class="existing-items">
-            {#each categories as category}
+            {#each categories as category (category.id)}
                 <div class="category">
                     <div use:name={category} />
                     <div class="color">


### PR DESCRIPTION
## Pull Request Description
When deleting event categories, the user interface does not re-render correctly. This is caused by a missing key, and fixed by adding one.

## Changes Proposed
Use `category.id` as a key to ensure it re-renders when it's supposed to.

## Related Issues
Fixes #187

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes
None.

BEGIN_COMMIT_OVERRIDE
fix: Fixes issue where deleting an event category would not properly refresh the UI
END_COMMIT_OVERRIDE