### PR TITLE
Fix calculation for weekdays and moon phases for calendars with leap months

### DIFF
--- a/src/stores/cache/moon-cache.ts
+++ b/src/stores/cache/moon-cache.ts
@@ -32,7 +32,7 @@ class DayMoonCache extends DayCache<MoonState> {
         const daysBefore = this.yearCalculator.daysBefore(this.getDate());
         for (let moon of moons ?? []) {
             const { offset, cycle } = moon;
-            const granularity = 24;
+            const granularity = 40;
 
             let data = (daysBefore - offset) / cycle;
             let position = data - Math.floor(data);

--- a/src/stores/calendar.store.ts
+++ b/src/stores/calendar.store.ts
@@ -370,12 +370,9 @@ export function getEphemeralStore(
         getPreviousMonth: (month: number, year: number) => {
             let yearStore = yearCalculator.getYearFromCache(year);
             if (month == 0) {
-                const config = get(staticStore.staticConfiguration);
-                if (config.useCustomYears && year > 0) {
-                    year = year - 1 || -1;
-                    yearStore = yearCalculator.getYearFromCache(year);
-                    month = get(yearStore.months).length - 1;
-                }
+                year = year - 1 || -1;
+                yearStore = yearCalculator.getYearFromCache(year);
+                month = get(yearStore.months).length - 1;
             } else {
                 month = month - 1;
             }

--- a/src/stores/years.store.ts
+++ b/src/stores/years.store.ts
@@ -59,11 +59,11 @@ export class YearStore {
         }
         return months.filter(
             (m) =>
-                !m.interval || (this.year - (m.offset ?? 0)) % m.interval == 0
+                m.interval == 1 || (this.year - (m.offset ?? 0)) % m.interval == 0
         );
     });
     daysBefore = derived(
-        [this.months, this.staticStore.leapDays],
+        [this.staticStore.months, this.staticStore.leapDays],
         ([months, leapDays]) => {
             return daysFromYearOne(this.year, months, leapDays);
         }

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -574,15 +574,20 @@ export function daysFromYearOne(
     leapDays: LeapDay[],
     includeIntercalary: boolean = false
 ) {
-    if (original == 1) return 0;
     let year = original >= 1 ? original : original + 1;
+    if (year == 1) return 0;
+
+    let actual_months = months.filter((m) => includeIntercalary || m.type == "month")
+
+    let days = 0
+    for (let i = 1; i <= Math.abs(year - 1); i++) {
+        days += actual_months
+            .filter((m) => (m.interval == 1) || (i - (m.offset ?? 0)) % m.interval == 0)
+            .reduce((a, b) => a + b.length, 0)
+    }
 
     return (
-        Math.abs(year - 1) *
-            months
-                .filter((m) => includeIntercalary || m.type == "month")
-                .reduce((a, b) => a + b.length, 0) +
-        leapDaysBeforeYear(original, leapDays)
+        days + leapDaysBeforeYear(original, leapDays)
     );
 }
 

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -5305,4 +5305,472 @@ export const PRESET_CALENDARS: PresetCalendar[] = [
             },
         ],
     },
+    {
+      name: "Naloren Calendar",
+      description: "Calendar established by the Naloren Empire and wildly known thanks to their world-spanning trade associations",
+
+      path: [],
+      supportInlineEvents: false,
+      inlineEventTag: "#inline-events",
+      showIntercalarySeparately: false,
+      static: {
+        incrementDay: false,
+        firstWeekDay: 0,
+        overflow: true,
+        weekdays: [
+          {
+            type: "day",
+            name: "Sunsday",
+            id: "ID_7af94bda1aab"
+          },
+          {
+            type: "day",
+            name: "Moonday",
+            id: "ID_2ada88ea4959"
+          },
+          {
+            type: "day",
+            name: "Godsday",
+            id: "ID_f869b859c8c9"
+          },
+          {
+            type: "day",
+            name: "Midweek",
+            id: "ID_1b991a4b8909"
+          },
+          {
+            type: "day",
+            name: "Thundersday",
+            id: "ID_5aba8afb9908"
+          },
+          {
+            type: "day",
+            name: "Freyasday",
+            id: "ID_1a2bc9ca4969"
+          },
+          {
+            type: "day",
+            name: "Shabbat",
+            id: "ID_283aeb9a9ab9"
+          }
+        ],
+        months: [
+          {
+            type: "month",
+            name: "Firstmonth",
+            length: 30,
+            id: "ID_eae8a818c8d9",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Secondmonth",
+            length: 29,
+            id: "ID_7a69aaaafb79",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Thirdmonth",
+            length: 30,
+            id: "ID_49ca3b4858aa",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Fourthmonth",
+            length: 29,
+            id: "ID_a93a98090af8",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Fifthmonth",
+            length: 30,
+            id: "ID_4b4a9a59585b",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Sixtmonth",
+            length: 29,
+            id: "ID_7b49e888b96b",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Seventhmonth",
+            length: 30,
+            id: "ID_4a492b3ab919",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Eightmonth",
+            length: 29,
+            id: "ID_5a9a9afa3989",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Ninthmonth",
+            length: 30,
+            id: "ID_79db9aa87938",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Tenthmonth",
+            length: 29,
+            id: "ID_2a4b9a7bda09",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Eleventhmonth",
+            length: 30,
+            id: "ID_5a790a4be829",
+            interval: 1,
+            offset: 0
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_1b2b8a4b8918",
+            interval: 19,
+            offset: 3
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_1bb8cb296beb",
+            interval: 19,
+            offset: 6
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_9bf849c9ea98",
+            interval: 19,
+            offset: 8
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_8b1a888baaf8",
+            interval: 19,
+            offset: 11
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_791ac8085aca",
+            interval: 19,
+            offset: 14
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_dbdb08790a6a",
+            interval: 19,
+            offset: 17
+          },
+          {
+            type: "month",
+            name: "Aleph",
+            length: 30,
+            id: "ID_4afb697b6a6b",
+            interval: 19,
+            offset: 19
+          },
+          {
+            type: "month",
+            name: "Twelvethmonth",
+            length: 29,
+            id: "ID_2b79d9398a4a",
+            interval: 1,
+            offset: 0
+          }
+        ],
+        moons: [
+          {
+            name: "Luna",
+            cycle: 29.531,
+            offset: 0,
+            faceColor: "#fff",
+            shadowColor: "#000",
+            id: "ID_e9fa7afb092a"
+          }
+        ],
+        displayMoons: true,
+        displayDayNumber: false,
+        leapDays: [
+          {
+            id: "ID_2a980a1b8ad8",
+            name: "Leap Day",
+            interval: [
+              {
+                interval: 5,
+                exclusive: false,
+                ignore: false
+              },
+              {
+                interval: 1000,
+                exclusive: true,
+                ignore: false
+              },
+              {
+                interval: 5000,
+                exclusive: false,
+                ignore: false
+              }
+            ],
+            intercalary: false,
+            timespan: 7,
+            offset: 0,
+            type: "leapday"
+          }
+        ],
+        eras: [
+          {
+            id: "ID_1908490bbb7b",
+            type: "era",
+            name: "Era of Legends",
+            description: "",
+            format: "{{era_name}}",
+            endsYear: false,
+            isEvent: false,
+            category: null,
+            isStartingEra: true,
+            date: {
+              year: 100,
+              month: 5,
+              day: 1
+            }
+          },
+          {
+            id: "ID_08995a29ab89",
+            type: "era",
+            name: "Era of Kings",
+            description: "",
+            format: "{{era_nth_year}} year of the {{era_name}}",
+            endsYear: false,
+            isEvent: false,
+            category: "",
+            isStartingEra: false,
+            date: {
+              year: 1,
+              month: 0,
+              day: 1
+            },
+            end: {
+              year: 231,
+              month: 0,
+              day: 1
+            }
+          },
+          {
+            id: "ID_db592b592a79",
+            type: "era",
+            name: "Era of the Republic",
+            description: "",
+            format: "{{era_nth_year}} year of the Republic",
+            endsYear: false,
+            isEvent: false,
+            category: null,
+            isStartingEra: false,
+            date: {
+              day: 1,
+              month: 0,
+              year: 231
+            },
+            end: {
+              day: 11,
+              month: 9,
+              year: 479
+            }
+          },
+          {
+            id: "ID_7a0a48489a1a",
+            type: "era",
+            name: "Era of the Empire",
+            description: "",
+            format: "{{era_nth_year}} year of the Empire",
+            endsYear: false,
+            isEvent: false,
+            category: null,
+            isStartingEra: false,
+            date: {
+              day: 19,
+              month: 8,
+              year: 538
+            }
+          }
+        ],
+        padMonths: 2,
+        padDays: 2
+      },
+      seasonal: {
+        seasons: [
+          {
+            id: "ID_cb0b4909b829",
+            name: "Spring",
+            color: "#a3c566",
+            type: "Periodic",
+            kind: "None",
+            duration: 91.31065789,
+            peak: 0,
+            weatherOffset: 56,
+            weatherPeak: 5.6000000000000005
+          },
+          {
+            id: "ID_79b8ba09ca6a",
+            name: "Summer",
+            color: "#fde2b4",
+            type: "Periodic",
+            kind: "None",
+            duration: 91.31065789,
+            peak: 0,
+            weatherOffset: 56,
+            weatherPeak: 5.6000000000000005
+          },
+          {
+            id: "ID_c8091aaa4a0b",
+            name: "Autumn",
+            color: "#de8c3c",
+            type: "Periodic",
+            kind: "None",
+            duration: 91.31065789,
+            peak: 0,
+            weatherOffset: 56,
+            weatherPeak: 5.6000000000000005
+          },
+          {
+            id: "ID_68dab80b4889",
+            name: "Winter",
+            color: "#8b8989",
+            type: "Periodic",
+            kind: "None",
+            duration: 91.31065789,
+            peak: 0,
+            weatherOffset: 56,
+            weatherPeak: 5.6000000000000005
+          }
+        ],
+        offset: 0,
+        type: "Periodic",
+        displayColors: true,
+        interpolateColors: true,
+        weather: {
+          enabled: true,
+          seed: 1,
+          tempUnits: UnitSystem.METRIC,
+          windUnits: UnitSystem.METRIC,
+          primaryWindDirection: "E",
+          freezingPoint: 0
+        }
+      },
+      locations: {
+        locations: [],
+      },
+      current: {
+        day: null,
+        month: null,
+        year: null
+      },
+      events: [
+        {
+          name: "Spring Equinox",
+          description: "Spring Equinox occurs when the sun crosses the equator from south to north, marked by both day and night being the same length.",
+          date: {
+            year: null,
+            month: null,
+            day: null
+          },
+          id: "ID_db68dbfbca8b",
+          note: null,
+          category: "ID_c96848991808",
+          sort: {
+            timestamp: 5E-324,
+            order: ""
+          },
+          type: "Undated"
+        },
+        {
+          name: "Summer Solstice",
+          description: "The summer solstice marks the longest day and shortest night of the year, when the sun is at its highest arc in the sky.",
+          date: {
+            year: null,
+            month: null,
+            day: null
+          },
+          id: "ID_09692b4aea7b",
+          note: null,
+          category: "ID_c96848991808",
+          sort: {
+            timestamp: 5E-324,
+            order: ""
+          },
+          type: "Undated"
+        },
+        {
+          name: "Autumn Equinox",
+          description: "Spring Equinox occurs when the sun crosses the equator from north to south, marked by both day and night being the same length.",
+          date: {
+            year: null,
+            month: null,
+            day: null
+          },
+          id: "ID_98fb9aaaea28",
+          note: null,
+          category: "ID_c96848991808",
+          sort: {
+            timestamp: 5E-324,
+            order: ""
+          },
+          type: "Undated"
+        },
+        {
+          name: "Winter Solstice",
+          description: "The summer solstice marks the shortest day and longest night of the year, when the sun is at its lowest arc in the sky.",
+          date: {
+            year: null,
+            month: null,
+            day: null
+          },
+          id: "ID_1999580aab9a",
+          note: null,
+          category: "ID_c96848991808",
+          sort: {
+            timestamp: 5E-324,
+            order: ""
+          },
+          type: "Undated"
+        }
+      ],
+      categories: [
+        {
+          id: "ID_c96848991808",
+          color: "#6ae868",
+          name: "Natural Events"
+        }
+      ],
+      id: null
+    }
 ];

--- a/test/leapDays.test.ts
+++ b/test/leapDays.test.ts
@@ -15,6 +15,9 @@ const GOLARION: Calendar = PRESET_CALENDARS.find(
 const HARPTOS: Calendar = PRESET_CALENDARS.find(
     (p) => p.name == "Calendar of Harptos"
 );
+const NALOREN: Calendar = PRESET_CALENDARS.find(
+    (p) => p.name == "Naloren Calendar"
+);
 
 test("Leap Days (Gregorian)", () => {
     expect(leapDaysBeforeYear(1, GREGORIAN.static.leapDays)).toBe(0);
@@ -44,4 +47,5 @@ test("Effective days in year", () => {
     expect(getEffectiveYearLength(GREGORIAN)).toBe(365.2425);
     expect(getEffectiveYearLength(HARPTOS)).toBe(365.25);
     expect(getEffectiveYearLength(GOLARION)).toBe(365.125);
+    expect(getEffectiveYearLength(NALOREN)).toBe(365.2518315789473);
 });

--- a/test/year.test.ts
+++ b/test/year.test.ts
@@ -6,6 +6,9 @@ import { vi, test, expect } from "vitest";
 const GREGORIAN: Calendar = PRESET_CALENDARS.find(
     (p) => p.name == "Gregorian Calendar"
 );
+const NALOREN: Calendar = PRESET_CALENDARS.find(
+    (p) => p.name == "Naloren Calendar"
+);
 
 test("Days Before Year (Gregorian)", () => {
     expect(
@@ -71,3 +74,66 @@ test("First Weekday (Gregorian)", () => {
         )
     ).toBe(1);
 });
+
+test("Leap month fuck with weekdays (Naloren)", () => {
+    expect(
+        getFirstDayOfYear(
+            3,
+            NALOREN.static.months,
+            NALOREN.static.weekdays,
+            NALOREN.static.leapDays,
+            NALOREN.static.overflow,
+            NALOREN.static.firstWeekDay,
+            NALOREN.static.offset
+        )
+    ).toBe(1);
+    expect(
+        getFirstDayOfYear(
+            4,
+            NALOREN.static.months,
+            NALOREN.static.weekdays,
+            NALOREN.static.leapDays,
+            NALOREN.static.overflow,
+            NALOREN.static.firstWeekDay,
+            NALOREN.static.offset
+        )
+    ).toBe(0);
+})
+test("Days before year (Naloren)", () => {
+    expect(
+        daysFromYearOne(1, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(0);
+    expect(
+        daysFromYearOne(2, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(354);
+    // year three is the first with a leap month
+    expect(
+        daysFromYearOne(4, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(354 * 3 + 30);
+    // The full 19-year cycle is 6936 days plus a few leap days long
+    expect(
+        daysFromYearOne(20, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(6936 + 3 /* specifically 3 leap days: y5, y10, y15 */);
+    expect(
+        daysFromYearOne(21, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(6936 + 354 + 4 /* leap days: y5, y10, y15, y20 */);
+    expect(
+        daysFromYearOne(77, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(4 * 6936 + 15);
+    expect(
+        daysFromYearOne(80, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(4 * 6936 + 3 * 354 + 30 + 15);
+    expect(
+        daysFromYearOne(191, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(10 * 6936 + 38);
+    expect(
+        daysFromYearOne(381, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(20 * 6936 + 76);
+    expect(
+        daysFromYearOne(773, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(40 * 6936 + 12 * 354 + 4 * 30 + 154);
+    // After 23,751 years the day/night and tropical year cycle match up *precisely*
+    expect(
+        daysFromYearOne(23_751, NALOREN.static.months, NALOREN.static.leapDays)
+    ).toBe(8_674_731);
+})


### PR DESCRIPTION
## Pull Request Description

Calendarium doesn't calculate the absolute passed days for a given date correctly if a leap month happened between the start of time and the given day. Since that number is used for a lot of things including moon phases this breaks stuff.

## Additional Notes

Please double-check this code carefully, I made these fixes months ago but didn't find the energy to package them and push them upstream until now.