### PR TITLE
fix: enable full-vault parsing on startup if no event paths are defined

### DIFF
--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -296,33 +296,59 @@ export class Watcher extends Component {
         return false;
     }
     start(calendar?: Calendar) {
-        if (!SettingsService.getData().autoParse) return;
+        if (!SettingsService.getData().autoParse) {
+            console.debug("watcher.start: autoParse disabled, skipping.");
+            return;
+        }
 
         const calendars = calendar
             ? [calendar]
             : SettingsService.getCalendars();
+
         if (!calendars.length) return;
 
         const folders = [];
+
         for (const [path] of SettingsService.getData().paths) {
             const folder = this.vault.getAbstractFileByPath(path);
-            if (!folder || !(folder instanceof TFolder)) return;
+            if (!folder || !(folder instanceof TFolder)) continue;
             folders.push(folder);
         }
-        if (!folders.length) return;
 
-        if (SettingsService.getData().debug) {
+        const { debug: isDebugMode } = SettingsService.getData();
+
+        if (isDebugMode) {
             if (calendar) {
                 console.info(`Starting rescan for ${calendar.name}`);
             } else {
                 console.info(
-                    `Starting rescan for ${calendars.length} calendars`
+                    `Starting rescan for ${calendars.length} calendars`,
                 );
-                console.info(`Looking at ${folders.length} paths`);
             }
         }
 
+        if (folders.length > 0) {
+            if (isDebugMode) {
+                console.info(
+                    `Event paths found. Scanning ${folders.length} paths.`,
+                );
+        }
+
         this.parseFiles(...folders);
+        } else {
+            if (isDebugMode) {
+                console.info(
+                    "No event paths found. Defaulting to full-vault parsing.",
+                );
+            }
+
+            const allFileNames = this.vault
+                .getAllLoadedFiles()
+                .filter((f) => f instanceof TFile && f.extension == "md")
+                .map((f) => f.path);
+
+            this.startParsing(allFileNames);
+        }
     }
     getFiles(abstract: TAbstractFile): string[] {
         let files = [];


### PR DESCRIPTION
## Pull Request Description
Allows for full-vault parsing of frontmatter and inline events on Obsidian startup. Without this, inline events and frontmatter events are "lost" upon closing Obsidian and will only return upon updating the file that they events are in.

Given the description of the `Event paths` setting says "Calendarium can be **restricted** to look at certain paths in your vault for events" this implies (to me) that if event paths are **not** defined, Calendarium can look at all events

## Changes Proposed
- [ ] When autoParse is enabled for events and no event paths are defined, parse the entire vault for frontmatter and inline events

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #233 


## Checklist
- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.



