### PR TITLE
updated Day.svelte with monthIndex 

### DIFF
--- a/src/calendar/ui/Day/Day.svelte
+++ b/src/calendar/ui/Day/Day.svelte
@@ -91,9 +91,10 @@
                 const func = new funct(
                     "day",
                     "calendar",
+                    "monthIndex",
                     $config.dayDisplayCallback,
                 );
-                number = func.call(undefined, day, $calendar) ?? number;
+                number = func.call(undefined, day, $calendar, $index) ?? number;
                 document.body.removeChild(frame);
             } catch (e) {
                 console.error(e);


### PR DESCRIPTION
## Pull Request Description

wanted a way to get month dependant display items in the calendar view using Day Callback 

## Changes Proposed
- [x] Changed Day.svelte adding "monthIndex" to the number assignment function, passing $index to expose it

## Related Issues
none

## Checklist


- [x ] I have read the contribution guidelines and code of conduct.
- [x ] I have tested the changes locally and they are working as expected.
- [x ] I have added appropriate comments and documentation for the code changes.
- [ x] My code follows the coding style and standards of this project.
- [x ] I have rebased my branch on the latest main (or master) branch.
- [ x] All tests (if applicable) have passed successfully.
- [ x] I have run linters and fixed any issues.
- [ x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)


## Additional Notes


